### PR TITLE
feat/meta: add robots/sitemap

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+
+import { NavigationPaths } from '@/types/endpoints';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: `/${NavigationPaths.Profile}/*`,
+    },
+    sitemap: `${process.env.APP_BASE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+
+const todayMidnight = new Date();
+todayMidnight.setHours(0, 0, 0, 0);
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: process.env.APP_BASE_URL!,
+      lastModified: todayMidnight,
+      changeFrequency: 'daily',
+      priority: 1,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary by Sourcery

Implement Next.js MetadataRoute handlers to serve robots.txt with default directives and a sitemap.xml with site URLs

New Features:
- Add /robots.txt metadata route with default rules and sitemap reference
- Add /sitemap.xml metadata route with initial URL entries