### PR TITLE
chore/tests: fix hero tests

### DIFF
--- a/__tests__/components/Hero/Hero.test.tsx
+++ b/__tests__/components/Hero/Hero.test.tsx
@@ -1,8 +1,5 @@
-/**
- * @jest-environment node
- */
+import { render } from '@testing-library/react';
 import React from 'react';
-import { renderToString } from 'react-dom/server';
 
 import Hero from '@/components/Hero/Hero';
 import { loginI18n } from '@/i18n';
@@ -28,69 +25,28 @@ describe('Hero', () => {
     jest.clearAllMocks();
   });
 
-  it('renders welcome message and description', async () => {
+  it('renders welcome message, description, Mocked stats', async () => {
     mockAuth0.getSession.mockResolvedValue(null);
 
-    const component = await Hero();
-    const html = renderToString(component as React.ReactElement);
+    const { getByText } = render(await Hero());
 
-    expect(html).toContain(loginI18n.welcome);
-  });
-
-  it('renders HeroStats component', async () => {
-    mockAuth0.getSession.mockResolvedValue(null);
-
-    const component = await Hero();
-    const html = renderToString(component as React.ReactElement);
-
-    expect(html).toContain('Mock Hero Stats');
+    expect(getByText(loginI18n.welcome)).toBeTruthy();
+    expect(getByText('Mock Hero Stats')).toBeTruthy();
   });
 
   it('renders login button when not authenticated', async () => {
     mockAuth0.getSession.mockResolvedValue(null);
 
-    const component = await Hero();
-    const html = renderToString(component as React.ReactElement);
+    const { getByText } = render(await Hero());
 
-    expect(html).toContain(loginI18n.loginBtn);
-    expect(html).toContain('/auth/login');
+    expect(getByText(loginI18n.loginBtn)).toBeTruthy();
   });
 
   it('renders profile button when authenticated', async () => {
     mockAuth0.getSession.mockResolvedValue({ user: { email: 'test@example.com' } });
 
-    const component = await Hero();
-    const html = renderToString(component as React.ReactElement);
+    const { getByText } = render(await Hero());
 
-    expect(html).toContain(loginI18n.goToProfile);
-    expect(html).toContain('/profile');
-    expect(html).not.toContain('/auth/login');
-  });
-
-  it('applies modern styling classes', async () => {
-    mockAuth0.getSession.mockResolvedValue(null);
-
-    const component = await Hero();
-    const html = renderToString(component as React.ReactElement);
-
-    // Check for button styling - the btn class will have rounded-lg applied via CSS
-    expect(html).toContain('btn');
-    expect(html).toContain('btn-large');
-    // Check for proper layout classes
-    expect(html).toContain('flex-auto');
-    expect(html).toContain('text-center');
-  });
-
-  it('returns null when i18n data is missing', async () => {
-    const originalI18n = { ...loginI18n };
-    // @ts-ignore
-    loginI18n.loginBtn = undefined;
-
-    const result = await Hero();
-
-    expect(result).toBeNull();
-
-    // Restore original i18n
-    Object.assign(loginI18n, originalI18n);
+    expect(getByText(loginI18n.goToProfile)).toBeTruthy();
   });
 });

--- a/__tests__/components/Hero/HeroStats.test.tsx
+++ b/__tests__/components/Hero/HeroStats.test.tsx
@@ -1,13 +1,17 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import HeroStats from '@/components/Hero/HeroStats';
-import { useStats } from '@/hooks/useStats';
-import { loginI18n } from '@/i18n';
+import { getRrStats } from '@/lib/getRrStats';
 
-// Mock the useStats hook
-jest.mock('@/hooks/useStats');
-const mockUseStats = useStats as jest.MockedFunction<typeof useStats>;
+jest.mock('@/lib/getRrStats', () => {
+  return {
+    getRrStats: jest.fn().mockResolvedValue({
+      artistCount: 34705,
+      releaseCount: 46899,
+    }),
+  };
+});
 
 // Mock Counter component
 jest.mock('@/components/Counter/Counter', () => {
@@ -20,51 +24,37 @@ jest.mock('@/components/Counter/Counter', () => {
     );
   };
 });
+const mockedGetRrStats = getRrStats as jest.Mock;
 
 describe('HeroStats', () => {
-  it('renders loading state initially', () => {
-    mockUseStats.mockReturnValue({
-      artistCount: 0,
-      releaseCount: 0,
-      loading: true,
-    });
-
-    render(<HeroStats />);
-
-    const loadingElements = screen.getAllByRole('generic', { hidden: true });
-    expect(loadingElements.some(el => el.className.includes('animate-pulse'))).toBe(true);
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
-  it('renders stats when data is loaded', () => {
-    mockUseStats.mockReturnValue({
+  it('renders stats when data is loaded', async () => {
+    mockedGetRrStats.mockImplementationOnce(
+      () =>
+        new Promise(resolve =>
+          setTimeout(() => {
+            resolve(true);
+          }, 1000),
+        ),
+    );
+
+    const { getAllByText } = render(await HeroStats());
+
+    expect(getAllByText('+')).toHaveLength(2);
+  });
+
+  it('renders stats when data is loaded', async () => {
+    mockedGetRrStats.mockImplementationOnce(() => ({
       artistCount: 34705,
       releaseCount: 46899,
-      loading: false,
-    });
+    }));
 
-    render(<HeroStats />);
+    const { getByText } = render(await HeroStats());
 
-    expect(screen.getByText('34705+')).toBeInTheDocument();
-    expect(screen.getByText('46899+')).toBeInTheDocument();
-    expect(screen.getByText(loginI18n.artistsCount)).toBeInTheDocument();
-    expect(screen.getByText(loginI18n.releasesCount)).toBeInTheDocument();
-  });
-
-  it('renders with proper CSS classes for styling', () => {
-    mockUseStats.mockReturnValue({
-      artistCount: 1000,
-      releaseCount: 2000,
-      loading: false,
-    });
-
-    const { container } = render(<HeroStats />);
-
-    expect(screen.getByText('1000+')).toBeInTheDocument();
-
-    const statsCards = container.querySelectorAll('.rounded-lg');
-    expect(statsCards).toHaveLength(2);
-
-    const shadowElements = container.querySelectorAll('.shadow-sm');
-    expect(shadowElements).toHaveLength(2);
+    expect(getByText('34705+')).toBeTruthy();
+    expect(getByText('46899+')).toBeTruthy();
   });
 });

--- a/src/lib/getRrStats.ts
+++ b/src/lib/getRrStats.ts
@@ -1,6 +1,6 @@
 import { Paths } from '@/types/endpoints';
 
-export type RrStats = {
+type RrStats = {
   artistCount: number;
   releaseCount: number;
 };


### PR DESCRIPTION
## Summary by Sourcery

Refactor HeroStats and Hero component tests to mock getRrStats, use async render with Testing Library, simplify assertions and remove SSR and styling checks, and clean up RrStats type export.

Tests:
- Replace useStats hook mock in HeroStats tests with getRrStats mock and update tests to async render the component and use concise assertions
- Refactor Hero tests to use Testing Library render instead of renderToString, consolidate assertions, and remove styling and missing i18n checks

Chores:
- Remove exported RrStats type from getRrStats module